### PR TITLE
[ProxyFix] FIX string.split() to return []

### DIFF
--- a/moflask/tests/wsgi_test.py
+++ b/moflask/tests/wsgi_test.py
@@ -74,3 +74,14 @@ class ProxyFixTest(TestCase):
         e['wsgi.url_scheme'] = 'https'
         fix.update_environ(env)
         self.assertEqual(e, env)
+
+    def test_no_proxy_works_transparently(self):
+        fix = ProxyFix(self.app_stub(['127.0.0.1']))
+        env = {
+            'REMOTE_ADDR': '127.0.0.1',
+            'HTTP_HOST': 'example.com',
+            'wsgi.url_scheme': 'http'
+        }
+        e = self._copy_env(env)
+        fix.update_environ(env)
+        self.assertEqual(e, env)

--- a/moflask/wsgi.py
+++ b/moflask/wsgi.py
@@ -40,7 +40,8 @@ class ProxyFix(object):
     def update_environ(self, environ):
         env = environ.get
         forwarded_proto = env('HTTP_X_FORWARDED_PROTO', '')
-        forwarded_for = env('HTTP_X_FORWARDED_FOR', '').split(',')
+        # the str.split() API needs a little help to convert a '' into a []
+        forwarded_for = list(filter(None, env('HTTP_X_FORWARDED_FOR', '').split(',')))
         forwarded_host = env('HTTP_X_FORWARDED_HOST', '')
         environ.update({
             'werkzeug.proxy_fix.orig_wsgi_url_scheme': env('wsgi.url_scheme'),


### PR DESCRIPTION
* `''` should return `[]`, but does return `['']` thus misleading the
  ProxyFix into believing, it is proxied by the IP `''`
* FIX: help `str.split()` returning our desired result