### PR TITLE
Get the LOG_FILE path from the environment by default

### DIFF
--- a/moflask/logging.py
+++ b/moflask/logging.py
@@ -20,6 +20,7 @@ Settings options:
 import json
 import logging
 import logging.handlers
+import os
 
 import flask
 from pythonjsonlogger import jsonlogger
@@ -143,7 +144,7 @@ def get_default_handler(config, filters=None):
 
 def get_json_file_handler(config, logger=None, filters=None):
     """Get a file handler with custom JSON formatting and context data."""
-    log_file = config.get("LOG_FILE", None)
+    log_file = config.get("LOG_FILE", os.environ.get("LOG_FILE", None))
     if log_file is None:
         return None
     # Check for existing handler before adding a new one.


### PR DESCRIPTION
Usually app instances are created in multiple processes (eg. the service serving HTTP requests and the flask shell). They should not log into the same file(s) as this would break the logfiles: Either one of them can’t log or they are not time-ordered as expected.

By allowing the environment to determine where to log it’s easy to disable logging (eg. not providing the variable for flask shell) and have different log files for different services by setting the environment variable in the services files.