### PR TITLE
rest.Client: Optionally return response.json() instead of the response

### DIFF
--- a/moflask/requests/rest.py
+++ b/moflask/requests/rest.py
@@ -26,7 +26,7 @@ class Client:
         verb = name.upper()
         return functools.partial(self.request, verb)
 
-    def request(self, method, *path_parts, path=None, url=None, **kwargs):
+    def request(self, method, *path_parts, path=None, url=None, json_response=False, **kwargs):
         """Send a request to the API-endpoint and handle the response.
 
         This accepts either of (the first of these wins):
@@ -45,4 +45,4 @@ class Client:
             url = self._base_url + path
         response = self._session.request(method, url, **kwargs)
         response.raise_for_status()
-        return response
+        return response.json() if json_response else response

--- a/moflask/requests/tests/rest_test.py
+++ b/moflask/requests/tests/rest_test.py
@@ -28,6 +28,17 @@ class ClientTest:
         assert not mock_request.called
 
     @staticmethod
+    @mock.patch("moflask.requests.sessions.Session.request")
+    def test_returning_data_as_response(mock_request):
+        """Test that Client.request(json_response=True) returns the json data."""
+        test_data = {"data": "test"}
+        mock_request.return_value = mock.Mock(json=mock.Mock(return_value=test_data))
+        assert mock_request().json() == test_data
+        client = rest.Client("https://example.org")
+        data = client.get(json_response=True)
+        assert data == {"data": "test"}
+
+    @staticmethod
     @mock.patch("requests.Session.send")
     def test_auth_middleware(mock_send):
         """Test that the a configured auth middleware is called and can manipulate the request."""


### PR DESCRIPTION
In the future that might become the default behaviour as we expect JSON responses in most cases.