### PR TITLE
Make dependency on flask-jwt-extended optional

### DIFF
--- a/moflask/pytest_plugin.py
+++ b/moflask/pytest_plugin.py
@@ -1,28 +1,40 @@
-"""Pre-defined pytest fixtures to be used in tests of the dependent apps."""
+"""Pre-defined pytest fixtures to be used in tests of the dependent apps.
+
+This plugin is loaded automatically when this module is installed which makes the fixtures
+available without further configuration.
+"""
 
 import contextlib
 from unittest import mock
 
 import pytest
 
-from . import jwt
+# Check whether flask_jwt_extended (optional dependency) is installed.
+JWT_INSTALLED = False
+try:
+    from . import jwt
+
+    JWT_INSTALLED = True
+except ModuleNotFoundError:
+    pass
 
 
-def _push_session_to_context(session):
-    context = jwt.ctx_stack.top
-    context.jwt = session.to_token_data()
-    context.jwt_user = {"loaded_user": session}
-    return None, context.jwt
+if JWT_INSTALLED:
 
+    def _push_session_to_context(session):
+        context = jwt.ctx_stack.top
+        context.jwt = session.to_token_data()
+        context.jwt_user = {"loaded_user": session}
+        return None, context.jwt
 
-@pytest.fixture(name="jwt_inject_session")
-def fixture_inject_session():
-    """Define a helper function to mock out JWT authentication checks."""
+    @pytest.fixture(name="jwt_inject_session")
+    def fixture_inject_session():
+        """Define a helper function to mock out JWT authentication checks."""
 
-    @contextlib.contextmanager
-    def inject_session(session):
-        with mock.patch("flask_jwt_extended.verify_jwt_in_request") as mock_verify:
-            mock_verify.side_effect = lambda *args, **kwargs: _push_session_to_context(session)
-            yield
+        @contextlib.contextmanager
+        def inject_session(session):
+            with mock.patch("flask_jwt_extended.verify_jwt_in_request") as mock_verify:
+                mock_verify.side_effect = lambda *args, **kwargs: _push_session_to_context(session)
+                yield
 
-    return inject_session
+        return inject_session


### PR DESCRIPTION
pytest plugins of the package are always included so we have to make sure that no imports fail in `pytest_plugin.py`