### PR TITLE
requests.auth: Simplify the app to app flow

### DIFF
--- a/moflask/requests/auth.py
+++ b/moflask/requests/auth.py
@@ -16,8 +16,8 @@ class AuthAppClient(rest.Client):
         """Create a new instance by reading the config from the Flask app config."""
         app = app or flask.current_app
         return cls(
-            app.config["IMPACT_STACK_AUTH_APP_URL"] + "/" + cls.AUTH_API_VERSION,
-            app.config["IMPACT_STACK_AUTH_APP_KEY"],
+            app.config["IMPACT_STACK_API_URL"] + "/auth/" + cls.AUTH_API_VERSION,
+            app.config["IMPACT_STACK_API_KEY"],
         )
 
     def __init__(self, base_url, api_key):

--- a/moflask/requests/tests/auth_test.py
+++ b/moflask/requests/tests/auth_test.py
@@ -14,8 +14,8 @@ from .. import auth
 def fixture_app():
     """Define a test Flask app."""
     app = flask.Flask("test-app")
-    app.config["IMPACT_STACK_AUTH_APP_URL"] = "https://auth.impact-stack.org"
-    app.config["IMPACT_STACK_AUTH_APP_KEY"] = "api-key"
+    app.config["IMPACT_STACK_API_URL"] = "https://impact-stack.net/api"
+    app.config["IMPACT_STACK_API_KEY"] = "api-key"
     with app.app_context():
         yield app
 
@@ -31,7 +31,7 @@ class AuthAppClientTest:
         token = client.get_token()
         assert token == "TOKEN.org1"
         assert len(requests_mock.request_history) == 1
-        assert requests_mock.request_history[0].url == "https://auth.impact-stack.org/v1/token"
+        assert requests_mock.request_history[0].url == "https://impact-stack.net/api/auth/v1/token"
         assert requests_mock.request_history[0].json() == "api-key"
 
 

--- a/moflask/requests/tests/auth_test.py
+++ b/moflask/requests/tests/auth_test.py
@@ -14,7 +14,7 @@ from .. import auth
 def fixture_app():
     """Define a test Flask app."""
     app = flask.Flask("test-app")
-    app.config["IMPACT_STACK_AUTH_APP_URL"] = "https://auth.impact-stack.org/v1"
+    app.config["IMPACT_STACK_AUTH_APP_URL"] = "https://auth.impact-stack.org"
     app.config["IMPACT_STACK_AUTH_APP_KEY"] = "api-key"
     with app.app_context():
         yield app
@@ -28,20 +28,11 @@ class AuthAppClientTest:
         """Test getting a token."""
         client = auth.AuthAppClient.from_app()
         requests_mock.post(rm.ANY, json={"token": "TOKEN.org1"})
-        token = client.get_token("org1")
-        assert token == "TOKEN.org1"
-
-    def test_get_token_for_sub_org(self, requests_mock):
-        """Test getting a token."""
-        client = auth.AuthAppClient.from_app()
-        requests_mock.post(rm.ANY, json={"token": "TOKEN.org1"})
-        token = client.get_token("parent>org1")
+        token = client.get_token()
         assert token == "TOKEN.org1"
         assert len(requests_mock.request_history) == 1
-        assert (
-            requests_mock.request_history[0].url
-            == "https://auth.impact-stack.org/v1/token/parent%3Eorg1"
-        )
+        assert requests_mock.request_history[0].url == "https://auth.impact-stack.org/v1/token"
+        assert requests_mock.request_history[0].json() == "api-key"
 
 
 @pytest.mark.usefixtures("app")
@@ -50,17 +41,17 @@ class AuthAppMiddlewareTest:
 
     def test_default_client_from_app_config(self):
         """Test that instantiating without a client uses client configured from the app config."""
-        middleware = auth.AuthAppMiddleware("org1")
+        middleware = auth.AuthAppMiddleware()
         assert isinstance(middleware.client, auth.AuthAppClient)
 
     def test_call_adds_header(self):
         """Test that the JWT token is added to the header."""
         client = mock.Mock(spec=auth.AuthAppClient)
         client.get_token.return_value = "TOKEN.org1"
-        middleware = auth.AuthAppMiddleware("org1", client=client)
+        middleware = auth.AuthAppMiddleware(client)
 
         request = mock.Mock(headers={})
         middleware(request)
-        assert client.method_calls == [mock.call.get_token("org1")]
+        assert client.method_calls == [mock.call.get_token()]
         assert "Authorization" in request.headers
         assert request.headers["Authorization"] == "Bearer TOKEN.org1"


### PR DESCRIPTION
Usually the app is configured with one API key that allows it to access all the resources it needs. If needed sub-organizations must be passed explicitly to the app’s API.