### PR TITLE
Use different keys for different types in logging

### DIFF
--- a/moflask/logging.py
+++ b/moflask/logging.py
@@ -82,10 +82,11 @@ def add_response_data(record):
     response = getattr(record, "_response", None)
     if response:
         record.response_status_code = response.status_code
+        record.response_body_text = response.text
         try:
-            record.response_body = response.json()
+            record.response_body_json = response.json()
         except json.decoder.JSONDecodeError:
-            record.response_body = response.text
+            pass
     return True
 
 

--- a/moflask/tests/logging_test.py
+++ b/moflask/tests/logging_test.py
@@ -3,6 +3,7 @@
 
 import logging as _logging
 
+import pytest
 import requests
 from flask import Flask
 from pythonjsonlogger.jsonlogger import JsonFormatter
@@ -111,8 +112,10 @@ def test_response_filter():
     logging.add_response_data(record)
     assert record.response_status_code
     assert record.response_status_code == 200
-    assert record.response_body
-    assert record.response_body == "Hello"
+    assert record.response_body_text
+    assert record.response_body_text == "Hello"
+    with pytest.raises(AttributeError):
+        assert record.response_body_json
 
 
 def test_response_filter_with_json():
@@ -125,6 +128,8 @@ def test_response_filter_with_json():
     logging.add_response_data(record)
     assert record.response_status_code
     assert record.response_status_code == 200
-    assert record.response_body
-    assert "test" in record.response_body
-    assert record.response_body["test"] == 1
+    assert record.response_body_text
+    assert record.response_body_text == '{"test": 1}'
+    assert record.response_body_json
+    assert "test" in record.response_body_json
+    assert record.response_body_json["test"] == 1


### PR DESCRIPTION
The response_body attribute should change data types. This can cause problems for log aggregators which want to do consistently parse values. Example: Elasticsearch.